### PR TITLE
[CHRON-10471] Add validator count to RabbitMQ new block message

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -958,7 +958,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 		let mut info = map![
 			"step".into() => step,
 			"signature".into() => signature,
-			"validatorCount".into() => validator_count.to_string()
+			"validatorCount".into() => format!("{:#x}", validator_count)
 		];
 
 		if header.number() >= self.empty_steps_transition {


### PR DESCRIPTION
Payload example:
```
{
   "author":"0xa89e44631762444ac4a554bd547274da7613532e",
   "difficulty":"0xfffffffffffffffffffffffffffffffc",
   "extraData":"0xde830205098f5061726974792d457468657265756d86312e33382e30826d61",
   "gasLimit":"0x2fefc800",
   "gasUsed":"0x0",
   "hash":"0xd85652e7583072325af295cf10d34f3e9b1588202c03770eeb3f9086c53af6f5",
   "logs":[

   ],
   "logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
   "miner":"0xa89e44631762444ac4a554bd547274da7613532e",
   "number":"0x3ef7",
   "parentHash":"0x87d318e57a07a201ca6b65f18cdc80207fd10087ae2ae941b3a311ed1695038a",
   "receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
   "sealFields":[
      "0x845ddc7ae6",
      "0xb84185f62dd8bc0093bd307c8c262838f63441b8e278e5e877822b5a75a3c34baf7c3c6652eda040f90bca395d3bf00b5278b28e43c8f929a97d05fbdbd2045e400f01"
   ],
   "sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
   "signature":"85f62dd8bc0093bd307c8c262838f63441b8e278e5e877822b5a75a3c34baf7c3c6652eda040f90bca395d3bf00b5278b28e43c8f929a97d05fbdbd2045e400f01",
   "size":"0x24c",
   "stateRoot":"0x85297a74a06e933e19b9d2be54c8eff6b8d1658149aed35422b4d69adc995a95",
   "step":"1574730470",
   "timestamp":"0x5ddc7ae6",
   "totalDifficulty":null,
   "transactions":[

   ],
   "transactionsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
   "uncles":[

   ],
   "validatorCount":"1"
}
```