### PR TITLE
[jl/CBK-1173] Respond NACK for requeue when publishing an error message fails

### DIFF
--- a/rabbitmq/src/client.rs
+++ b/rabbitmq/src/client.rs
@@ -167,6 +167,7 @@ impl<C: 'static + miner::BlockChainClient + BlockChainClient> PubSubClient<C> {
 									).map(|_| ())
 								}))
 								.map(|_| ConsumerResult::ACK)
+								.or_else(|_| ok(ConsumerResult::NACK(true)))
 							)
 						}),
 					)


### PR DESCRIPTION
When register_consumer() method's callback in rabbitmq_adapter receives an error, it responds with NACK with requeue option as false.
However, in this case, where the client tries to publish a different error message to RabbitMQ server but this process fails, we should send a NACK with requeue so that the error message does not go missing and becomes undetectable.

Note: this will be part of epic CHRON-10383 for QA and release purposes.